### PR TITLE
Fixed heading updates being missed due to monitoring plugin-caused edits

### DIFF
--- a/src/ManageToc.ts
+++ b/src/ManageToc.ts
@@ -148,9 +148,6 @@ export class ManageToc {
                 break;
         }
 
-        // Set the flag to indicate plugin-initiated changes
-        this.plugin.isPluginEdit = true;
-
         // Replace the old TOC with the updated TOC
         this.validator.editor.replaceRange(
             newTocBlock, tocInsertRange.from, tocInsertRange.to

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,12 +24,12 @@ import { Validator } from './validator';
 export default class InstaTocPlugin extends Plugin {
 	public app: App;
 	public settings: InstaTocSettings;
+	public activeFile: TFile | null = null;
 	private validator: Validator | undefined;
 	private modifyEventRef: EventRef | undefined;
 	private debouncer: Debouncer<[fileCache: CachedMetadata], void>;
 
 	// Flags to maintain state with updates
-	public isPluginEdit = false;
 	public hasTocBlock = true;
 
 	public getDelay = () => this.settings.updateDelay;
@@ -140,12 +140,6 @@ export default class InstaTocPlugin extends Plugin {
 	public setDebouncer(): void {
 		this.debouncer = debounce(
 			(fileCache: CachedMetadata) => {
-				// Ignore updates performed by ManageToc.ts
-				if (this.isPluginEdit) {
-					this.isPluginEdit = false;
-					return;
-				}
-
 				const { editor, cursorPos }: EditorData = getEditorData(this.app);
 
 				if (!editor || !cursorPos) return;


### PR DESCRIPTION
Originally, I was tracking updates caused by the plugin itself toward the code block in order to skip said updates for performance reasons. This led to headings not being updated within the ToC.

This update removes this additional check to ensure all updates are passed to the ToC.