### PR TITLE
Remove numbered list workaround

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "insta-toc",
     "name": "Insta TOC",
-    "version": "6.4.0",
+    "version": "6.4.1",
     "minAppVersion": "0.15.0",
     "description": "Simultaneously generate, update, and maintain a table of contents for your notes.",
     "author": "Nick C.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "insta-toc",
-    "version": "6.4.0",
+    "version": "6.4.1",
     "description": "Simultaneously generate, update, and maintain a table of contents for your notes in real time.",
     "repository": {
         "directory": ".",

--- a/src/ManageToc.ts
+++ b/src/ManageToc.ts
@@ -138,23 +138,10 @@ export class ManageToc {
         newTocBlock: string,
         tocInsertRange: EditorRange
     ): void {
-        const smartListEnabled: boolean = this.app.vault.config.smartIndentList === true;
-
-        if (smartListEnabled && this.isNumberedToc) {
-            this.hasSmartList = true;
-            this.app.vault.setConfig('smartIndentList', false);
-        }
-
         // Replace the old TOC with the updated TOC
         this.validator.editor.replaceRange(
             newTocBlock, tocInsertRange.from, tocInsertRange.to
         );
-
-        if (this.hasSmartList) {
-            this.hasSmartList = false;
-            this.isNumberedToc = false;
-            this.app.vault.setConfig('smartIndentList', true);
-        }
     }
 
     // Dynamically update the TOC


### PR DESCRIPTION
The numbered list bug was fixed in Obsidian v1.8.10, therefore I've removed the workaround used to circumnavigate the bug.